### PR TITLE
Fix missing "Try it out!" button target on index page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -28,7 +28,7 @@ const HeroWrapper = styled.div`
 const Hero = () => (
   <HeroWrapper>
     <DocumentGraphicImage />
-    <Button primary>Try it out!</Button>
+    <Button href="/repl" primary>Try it out!</Button>
   </HeroWrapper>
 );
 


### PR DESCRIPTION
This PR fixes a missing `href` attribute, to link the "try it out" button in the index page to the actual playground.