### PR TITLE
Fix function brackets in BlobProvider example

### DIFF
--- a/docs/on-the-fly.md
+++ b/docs/on-the-fly.md
@@ -44,10 +44,10 @@ const MyDoc = (
 const App = () => (
   <div>
     <BlobProvider document={MyDoc}>
-      {({ blob, url, loading, error }) => (
+      {({ blob, url, loading, error }) => {
         // Do whatever you need with blob here
         return <div>There's something going on on the fly</div>
-      )}
+      }}
     </BlobProvider>
   </div>
 );


### PR DESCRIPTION
Since the `BlobProvider` render function is calling `return <div>...`, it needs to use curly braces instead of parens