### PR TITLE
Update links to advanced topics for components

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -4,12 +4,12 @@ A React component for displaying network or local (Node only) JPG or PNG images,
 
 #### Valid props
 
-| Prop name |                                Description                                 |              Type |     Default |
-| --------- | :------------------------------------------------------------------------: | ----------------: | ----------: |
-| src       |                              Valid image URL                               |          _String_ | _undefined_ |
-| style     |                 Defines view styles. [See more](#styling)                  | _Object_, _Array_ | _undefined_ |
-| debug     |      Enables debug mode on view bounding box. [See more](#debugging)       |         _Boolean_ |     _false_ |
+| Prop name |                                 Description                                |              Type |     Default |
+|-----------|:--------------------------------------------------------------------------:|------------------:|------------:|
+| src       |                               Valid image URL                              |          _String_ | _undefined_ |
+| style     |                  Defines view styles. [See more](/styling)                 | _Object_, _Array_ | _undefined_ |
+| debug     |  Enables debug mode on view bounding box. [See more](/advanced#debugging)  |         _Boolean_ |     _false_ |
 | fixed     | Render component in all wrapped pages. [See more](/advanced#page-wrapping) |         _Boolean_ |     _false_ |
-| cache     |             Enables image caching between consecutive renders              |         _Boolean_ |      _true_ |
+| cache     |              Enables image caching between consecutive renders             |         _Boolean_ |      _true_ |
 
 ---

--- a/docs/link.md
+++ b/docs/link.md
@@ -4,12 +4,12 @@ A React component for displaying an hyperlink. Link’s can be nested inside a T
 
 #### Valid props
 
-| Prop name |                                Description                                 |              Type |     Default |
-| --------- | :------------------------------------------------------------------------: | ----------------: | ----------: |
-| src       |                                 Valid URL                                  |          _String_ | _undefined_ |
-| wrap      |    Enable/disable page wrapping for element [See more](#page-wrapping)     |         _Boolean_ |      _true_ |
-| style     |                 Defines view styles. [See more](#styling)                  | _Object_, _Array_ | _undefined_ |
-| debug     |      Enables debug mode on view bounding box. [See more](#debugging)       |         _Boolean_ |     _false_ |
-| fixed     | Render component in all wrapped pages. [See more](/advanced#page-wrapping) |         _Boolean_ |     _false_ |
+| Prop name |                                  Description                                 |              Type |     Default |
+|-----------|:----------------------------------------------------------------------------:|------------------:|------------:|
+| src       |                                   Valid URL                                  |          _String_ | _undefined_ |
+| wrap      | Enable/disable page wrapping for element [See more](/advanced#page-wrapping) |         _Boolean_ |      _true_ |
+| style     |                   Defines view styles. [See more](/styling)                  | _Object_, _Array_ | _undefined_ |
+| debug     |   Enables debug mode on view bounding box. [See more](/advanced#debugging)   |         _Boolean_ |     _false_ |
+| fixed     |  Render component in all wrapped pages. [See more](/advanced#page-wrapping)  |         _Boolean_ |     _false_ |
 
 ---

--- a/docs/note.md
+++ b/docs/note.md
@@ -6,7 +6,7 @@ A React component for displaying a note annotation inside the document.
 
 | Prop name |                                Description                                 |              Type |     Default |
 | --------- | :------------------------------------------------------------------------: | ----------------: | ----------: |
-| style     |                 Defines view styles. [See more](#styling)                  | _Object_, _Array_ | _undefined_ |
+| style     |                 Defines view styles. [See more](/styling)                  | _Object_, _Array_ | _undefined_ |
 | children  |                            Note string content                             |          _String_ | _undefined_ |
 | fixed     | Render component in all wrapped pages. [See more](/advanced#page-wrapping) |         _Boolean_ |     _false_ |
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -4,13 +4,13 @@ A React component for displaying text. Text supports nesting of other Text or Li
 
 #### Valid props
 
-| Prop name           |                                  Description                                   |              Type |     Default |
-| ------------------- | :----------------------------------------------------------------------------: | ----------------: | ----------: |
-| wrap                |      Enable/disable page wrapping for element [See more](#page-wrapping)       |         _Boolean_ |      _true_ |
-| render              | Render dynamic content based on context [See more](#rendering-dynamic-content) |        _Function_ | _undefined_ |
-| style               |                   Defines view styles. [See more](#styling)                    | _Object_, _Array_ | _undefined_ |
-| debug               |        Enables debug mode on view bounding box. [See more](#debugging)         |         _Boolean_ |     _false_ |
-| fixed               |   Render component in all wrapped pages. [See more](/advanced#page-wrapping)   |         _Boolean_ |     _false_ |
-| hyphenationCallback |              Specify how much hyphenated breaks should be avoided              |         _Integer_ |       _600_ |
+| Prop name           |                                  Description                                  |              Type |     Default |
+|---------------------|:-----------------------------------------------------------------------------:|------------------:|------------:|
+| wrap                |  Enable/disable page wrapping for element [See more](/advanced#page-wrapping) |         _Boolean_ |      _true_ |
+| render              | Render dynamic content based on context [See more](/advanced#dynamic-content) |        _Function_ | _undefined_ |
+| style               |                   Defines view styles. [See more](/styling)                   | _Object_, _Array_ | _undefined_ |
+| debug               |    Enables debug mode on view bounding box. [See more](/advanced#debugging)   |         _Boolean_ |     _false_ |
+| fixed               |   Render component in all wrapped pages. [See more](/advanced#page-wrapping)  |         _Boolean_ |     _false_ |
+| hyphenationCallback |              Specify how much hyphenated breaks should be avoided             |         _Integer_ |       _600_ |
 
 ---

--- a/docs/view.md
+++ b/docs/view.md
@@ -4,12 +4,12 @@ The most fundamental component for building a UI and is designed to be nested in
 
 #### Valid props
 
-| Prop name |                                  Description                                   |              Type |     Default |
-| --------- | :----------------------------------------------------------------------------: | ----------------: | ----------: |
-| wrap      |      Enable/disable page wrapping for element [See more](#page-wrapping)       |         _Boolean_ |     _true_ |
-| style     |                   Defines view styles. [See more](#styling)                    | _Object_, _Array_ | _undefined_ |
-| render    | Render dynamic content based on context [See more](#rendering-dynamic-content) |        _Function_ | _undefined_ |
-| debug     |        Enables debug mode on view bounding box. [See more](#debugging)         |         _Boolean_ |     _false_ |
-| fixed     |   Render component in all wrapped pages. [See more](/advanced#page-wrapping)   |         _Boolean_ |     _false_ |
+| Prop name |                                  Description                                  |              Type |     Default |
+|-----------|:-----------------------------------------------------------------------------:|------------------:|------------:|
+| wrap      |  Enable/disable page wrapping for element [See more](/advanced#page-wrapping) |         _Boolean_ |      _true_ |
+| style     |                   Defines view styles. [See more](/styling)                   | _Object_, _Array_ | _undefined_ |
+| render    | Render dynamic content based on context [See more](/advanced#dynamic-content) |        _Function_ | _undefined_ |
+| debug     |    Enables debug mode on view bounding box. [See more](/advanced#debugging)   |         _Boolean_ |     _false_ |
+| fixed     |   Render component in all wrapped pages. [See more](/advanced#page-wrapping)  |         _Boolean_ |     _false_ |
 
 ---


### PR DESCRIPTION
There was a number of dead links on the https://react-pdf.org/components page. This PR corrects the links to point to the correct Advanced link.

@diegomura 
