### PR TITLE
Update documentation example for disabling hyphenation

### DIFF
--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -105,12 +105,10 @@ Font.registerHyphenationCallback(hyphenationCallback);
 
 #### Disabling hyphenation
 
-You can easily disable word hyphenation by just returning all words as they are passed to hte hyphenation callback
+You can easily disable word hyphenation by just returning all words as they are passed to the hyphenation callback
 
 ```
-Font.registerHyphenationCallback(words => (
-  words.map(word => [word])
-));
+Font.registerHyphenationCallback(word => [word]);
 ```
 
 <GoToExample name="disable-hyphenation" />


### PR DESCRIPTION
This tripped me up for a while, then I found this issue raised on the main repo: https://github.com/diegomura/react-pdf/issues/417.

Looks like this part of the documentation was just missed when the docs were updated with the change to `registerHyphenationCallback`.