### PR TITLE
webpack settings

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -7,6 +7,7 @@ import DynamicContent from './dynamic-content.md'
 import Hyphenation from './hyphenation.md'
 import Debugging from './debugging.md'
 import Ruler from './ruler.md'
+import Webpack from './webpack.md'
 
 <EditButton to="https://github.com/react-pdf/site/blob/master/docs/advanced.md" />
 
@@ -19,6 +20,7 @@ import Ruler from './ruler.md'
 <Debugging components={components} />
 <Ruler components={components} />
 <Hyphenation components={components} />
+<Webpack components={components} />
 
 <NavigationButtons
   backSrc="/styling"

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -1,0 +1,23 @@
+### Webpack config `web only`
+
+React-pdf is built on top of [PDFKit](http://pdfkit.org/), which for browser usage requires a couple of node.js API shims.
+
+If you use webpack you may need to include the following settings to your config:
+
+```json
+{
+  ...
+  node : {
+    module: 'empty',
+    dgram: 'empty',
+    dns: 'mock',
+    fs: 'empty',
+    http2: 'empty',
+    net: 'empty',
+    tls: 'empty',
+    child_process: 'empty',
+  }
+}
+```
+
+If you are using _create-react-app_, those are already included.

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -140,6 +140,7 @@ const Menu = ({ opened, onItemClick, ...props }) => (
         <Item to="/advanced#debugging" title="Debugging" onClick={onItemClick} />
         <Item to="/advanced#ruler" title="Ruler" onClick={onItemClick} />
         <Item to="/advanced#hyphenation" title="Hyphenation" onClick={onItemClick} />
+        <Item to="/advanced#webpack-config" title="Webpack config" onClick={onItemClick} />
       </Item>
       <Item to="/repl" title="Playground / REPL" onClick={onItemClick} />
       <Item to="https://opencollective.com/react-pdf" title="Donate" onClick={onItemClick} />


### PR DESCRIPTION
Some additional info on how to fix a custom webpack config in order for react-pdf to work.

I noticed that react-pdf would build fine in create-react-app, but not in next.js, so I dug into CRA-scripts and found that config setting.