### PR TITLE
fixed typos and corrected grammatical errors

### DIFF
--- a/docs/canvas.md
+++ b/docs/canvas.md
@@ -9,7 +9,7 @@ A React component for freely drawing any content on the page.
 | style     |                 Defines view styles. [See more](/styling)                  | _Object_, _Array_ | _undefined_ |
 | paint     |                              Painter function                              |        _Function_ | _undefined_ |
 | debug     |  Enables debug mode on view bounding box. [See more](/advanced#debugging)  |         _Boolean_ |     _false_ |
-| fixed     | Render component in all wrapped pages. [See more](/advanced#page-wrapping) |         _Boolean_ |     _false_ |
+| fixed     | Renders component in all wrapped pages. [See more](/advanced#page-wrapping) |         _Boolean_ |     _false_ |
 
 React-pdf does not check how much space your drawing takes, so make sure you always define a `width` and `height` on the `style` prop.
 
@@ -23,7 +23,7 @@ Prop used to perform drawings inside the Canvas. It takes 3 arguments:
 
 ##### Painter object
 
-Wrapper arround _pdfkit_ methods you can use to draw inside the Canvas. All operations are chainable. For more informationabout how these methods work, please refer to [pdfkit documentation](http://pdfkit.org/).
+Wrapper arround _pdfkit_ methods you can use to draw inside the Canvas. All operations are chainable. For more information about how these methods work, please refer to [pdfkit documentation](http://pdfkit.org/).
 
 Available methods:
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -16,7 +16,7 @@ import BlobProvider from './blobprovider.md'
 
 ## Components
 
-React-pdf follows the [React primitives](https://github.com/lelandrichardson/react-primitives) specification, making the learning process very straightforward if you come from another React environment (such as react-native). Additionally, it implements custom Component types that allows you to structure your PDF document.
+React-pdf follows the [React primitives](https://github.com/lelandrichardson/react-primitives) specification, making the learning process very straightforward if you come from another React environment (such as react-native). Additionally, it implements custom Component types that allow you to structure your PDF document.
 
 <Document components={components} />
 <Page components={components} />

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -3,7 +3,7 @@ import GoToExample from '../src/components/GoToExample'
 
 ### Debugging
 
-React-pdf ships a built-in debugging system you can use whenever you have doubts about how elements are being laid out on the page. All you have to do is set the `debug` prop to `true` on any valid primitive (except _Document_) and re-render the document to see the result on the screen.
+React-pdf ships a built-in debugging system you can use whenever you have doubts about how elements are being laid out on the page. All you have to do is to set the `debug` prop to `true` on any valid primitive (except _Document_) and re-render the document to see the result on the screen.
 
 <DebugSample />
 

--- a/docs/document.md
+++ b/docs/document.md
@@ -1,6 +1,6 @@
 ### Document
 
-This component represent the PDF document itself. It _must_ be the root of your tree element structure, and under no circumstances should it be used as children of another react-pdf component. In addition, it should only have childs of type `<Page />`.
+This component represents the PDF document itself. It _must_ be the root of your tree element structure, and under no circumstances should it be used as child of another react-pdf component. In addition, it should only have children of type `<Page />`.
 
 #### Valid props
 

--- a/docs/dynamic-content.md
+++ b/docs/dynamic-content.md
@@ -2,7 +2,7 @@ import GoToExample from '../src/components/GoToExample'
 
 ### Dynamic content
 
-With react-pdf it is now possible to render dynamic text based on the context in which a certain element is being rendered. All you have to do is to pass a function to the `render` prop of the `<Text />` or `<View />` component. The result will be rendered inside the text block as children.
+With react-pdf, now it is possible to render dynamic text based on the context in which a certain element is being rendered. All you have to do is to pass a function to the `render` prop of the `<Text />` or `<View />` component. The result will be rendered inside the text block as a child.
 
 ```
 import { Document, Page } from '@react-pdf/renderer'

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -2,9 +2,9 @@ import GoToExample from '../src/components/GoToExample'
 
 ## Fonts
 
-React-pdf is shipped with a `Font` module that enables to load fonts from different sources, handle how words are wrapped and define an emoji source to embed these glyphs on your document.
+React-pdf is shipped with a `Font` module that enables to load fonts from different sources, handle how words are wrapped and defined an emoji source to embed these glyphs on your document.
 
-You can define multiple sources for the same font family, each with a different `fontStyle` or `fontWeight`. React-pdf will pick the appropiate font for each `<Text />` based on it's style and the registered fonts.
+You can define multiple sources for the same font family, each with a different `fontStyle` or `fontWeight`. React-pdf will pick the appropiate font for each `<Text />` based on its style and the registered fonts.
 
 
 ```
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
 
 ### `register`
 
-Fonts really make the difference when it comes on styling a document. For obvious reasons, react-pdf cannot ship a wide amount of them. That why we provide an easy way to load your custom fonts from many different sources via the `register` method vey easily.
+Fonts really make the difference when it comes on styling a document. For obvious reasons, react-pdf cannot ship a wide amount of them. That's why we provide an easy way to load your custom fonts from many different sources via the `register` method very easily.
 
 ```
 import { Font } from '@react-pdf/renderer'

--- a/docs/hyphenation.md
+++ b/docs/hyphenation.md
@@ -6,7 +6,7 @@ Hyphenation refers to the automated process of breaking words between lines to c
 
 React-pdf internally implements the [Knuth and Plass line breaking algorithm](http://www3.interscience.wiley.com/journal/113445055/abstract) that produces the minimum amount of lines without compromising text legibility. By default it's setup to hyphenate english words.
 
-If you need more fine-grained control over how words break, you can pass your own callback and handle all that logic for yourself:
+If you need more fine-grained control over how words break, you can pass your own callback and handle all that logic by yourself:
 
 ```
 import { Font } from '@react-pdf/renderer'

--- a/docs/image.md
+++ b/docs/image.md
@@ -10,7 +10,7 @@ A React component for displaying network or local (Node only) JPG or PNG images,
 | source                          |                    Alias of _src_ [See Source object](/components#source-object)                    |   _Source object_ | _undefined_ |
 | style                           |                              Defines view styles. [See more](/styling)                              | _Object_, _Array_ | _undefined_ |
 | debug                           |              Enables debug mode on view bounding box. [See more](/advanced#debugging)               |         _Boolean_ |     _false_ |
-| fixed                           |             Render component in all wrapped pages. [See more](/advanced#page-wrapping)              |         _Boolean_ |     _false_ |
+| fixed                           |             Renders component in all wrapped pages. [See more](/advanced#page-wrapping)              |         _Boolean_ |     _false_ |
 | cache                           |                          Enables image caching between consecutive renders                          |         _Boolean_ |      _true_ |
 | safePath                        |                  The safe path from which local images (Node only) can be rendered                  |          _String_ |  _./public_ |
 | allowDangerousPaths `Node only` | Allows local images to be retrieved from paths outside the _safePath_. _Use this at your own risk!_ |         _Boolean_ |     _false_ |
@@ -22,7 +22,7 @@ Defines the source of an image. Can be in any of these three valid froms:
 | Form type   |                                                            Description                                                             | Example                                                    |
 | ----------- | :--------------------------------------------------------------------------------------------------------------------------------: | ---------------------------------------------------------- |
 | String      |                                           Valid image URL or filesystem path (Node only)                                           | `www.react-pdf.org/test.jpg`                               |
-| URL object  |                                       Enable to pass extra parameters on how to fetch images                                       | `{ uri: valid-url, method: 'GET', headers: {}, body: '' }` |
-| Data buffer | Render buffer image via the _data_ key. It's also recommended to provide the image _format_ so the engine knows how to proccess it | `{ data: Buffer, format: 'png' \| 'jpg' }`                 |
+| URL object  |                                       Enables to pass extra parameters on how to fetch images                                       | `{ uri: valid-url, method: 'GET', headers: {}, body: '' }` |
+| Data buffer | Renders buffer image via the _data_ key. It's also recommended to provide the image _format_ so the engine knows how to proccess it | `{ data: Buffer, format: 'png' \| 'jpg' }`                 |
 
 ---

--- a/docs/note.md
+++ b/docs/note.md
@@ -8,6 +8,6 @@ A React component for displaying a note annotation inside the document.
 | --------- | :------------------------------------------------------------------------: | ----------------: | ----------: |
 | style     |                 Defines view styles. [See more](/styling)                  | _Object_, _Array_ | _undefined_ |
 | children  |                            Note string content                             |          _String_ | _undefined_ |
-| fixed     | Render component in all wrapped pages. [See more](/advanced#page-wrapping) |         _Boolean_ |     _false_ |
+| fixed     | Renders component in all wrapped pages. [See more](/advanced#page-wrapping) |         _Boolean_ |     _false_ |
 
 ---

--- a/docs/page-wrapping.md
+++ b/docs/page-wrapping.md
@@ -2,7 +2,7 @@ import GoToExample from '../src/components/GoToExample'
 
 ### Page wrapping
 
-Semantically, the `<Page />` component represents a single page in the rendered document. However, there are scenarios in which you would expect to have page breaks whenever the page contents exceeds their limits, specially when handling big chunks of text. After all, PDFs are paged documents. React-pdf has a build-in wrapping engine that is enabled by default, so you can start creating paged documents right out of the box. If that's not what you need, you can disable this very easily by doing:
+Semantically, the `<Page />` component represents a single page in the rendered document. However, there are scenarios in which you would expect to have page breaks whenever the page contents exceed their limits, specially when handling big chunks of text. After all, PDFs are paged documents. React-pdf has a build-in wrapping engine that is enabled by default, so you can start creating paged documents right out of the box. If that's not what you need, you can disable this very easily by doing:
 
 ```
 import { Document, Page } from '@react-pdf/renderer'
@@ -22,7 +22,7 @@ const doc = () => (
 
 We can identify two different types of components based on how they wrap:
 
-- `Breakable components` tries to fill up the remaining space before jumping into a new page. By default, this group is composed by _View_, _Text_ and _Link_ components
+- `Breakable components` try to fill up the remaining space before jumping into a new page. By default, this group is composed by _View_, _Text_ and _Link_ components
 - `Unbreakable components` are indivisible, therefore if there isn't enough space for them they just get rendered in the following page. In this group by default we only find _Image_.
 
 <GoToExample name="breakable-unbreakable" />
@@ -45,7 +45,7 @@ const doc = () => (
 );
 ```
 
-Now, if the `<View />` components happens to be at the bottom of the page without enough space, it will be rendered in a new page as he would be _unbreakable_.
+Now, if the `<View />` component happens to be at the bottom of the page without enough space, it will be rendered in a new page as it would be _unbreakable_.
 
 <GoToExample name="disable-wrapping" />
 
@@ -73,7 +73,7 @@ const doc = () => (
 
 #### Fixed components
 
-There is still another scenario we didn't talk about yet: what if I want to wrap pages but also be able to render a component on _all_ pages? This is where the `fixed` prop comes into play.
+There is still another scenario we didn't talk about yet: what if you want to wrap pages but also be able to render a component on _all_ pages? This is where the `fixed` prop comes into play.
 
 ```
 import { Document, Page, View } from '@react-pdf/renderer'

--- a/docs/page.md
+++ b/docs/page.md
@@ -1,6 +1,6 @@
 ### Page
 
-Represents single page inside the PDF document, or a subset of them if using the wrapping feature. A `<Document />` can contain as many pages as you want, but ensure not rendering a page inside any component besides Document.
+Represents single page inside the PDF documents, or a subset of them if using the wrapping feature. A `<Document />` can contain as many pages as you want, but ensures not rendering a page inside any component besides Document.
 
 #### Valid props
 
@@ -8,7 +8,7 @@ Represents single page inside the PDF document, or a subset of them if using the
 | -------------------- | :----------------------------------------------------------------------------------------------------------------------: | --------------------------: | -----------: |
 | size                 | Defines page size. If _String_, must be one of the [available page sizes](https://github.com/diegomura/react-pdf/blob/master/src/utils/pageSizes.js). Height is optional, if ommited it will behave as "auto". | _String_, _Array_, _Number_, _Object_ |       _"A4"_ |
 | orientation          |                           Defines page orientation. _Valid values: "portrait" or "landscape"_                            |                    _String_ | _"portrait"_ |
-| wrap                 |                         Enable page wrapping for this page. [See more](/advanced#page-wrapping)                          |                   _Boolean_ |       _true_ |
+| wrap                 |                         Enables page wrapping for this page. [See more](/advanced#page-wrapping)                          |                   _Boolean_ |       _true_ |
 | style                |                                        Defines page styles. [See more](/styling)                                         |           _Object_, _Array_ |  _undefined_ |
 | debug                |                         Enables debug mode on page bounding box. [See more](/advanced#debugging)                         |                   _Boolean_ |      _false_ |
 | ruler                |                       Enables vertical and horizontal rulers on page. [See more](/advanced#ruler)                        |                   _Boolean_ |      _false_ |

--- a/docs/rendering-process.md
+++ b/docs/rendering-process.md
@@ -14,7 +14,7 @@ At a high level, the document creation process is composed by 6 concrete steps.
 
 The first step involves transforming the _React element tree_ into the appropriate internal instances for each component type. This involves saving the relationship between these (parent-child), parsing styles and processing props.
 
-Besides **Document**, all nodes will represent a block inside a document, with a height, width, paddings and margins (yet to be discovered). This instances also define how each element wraps in the page, how their dimensions are calculated, and finally, how they get rendered in the document.
+Besides **Document**, all nodes will represent a block inside a document, with a height, width, paddings and margins (yet to be discovered). These instances also define how each element wraps in the page, how their dimensions are calculated, and finally, how they get rendered in the document.
 
 From now on, react-pdf works over this data structure to start inferring where each block goes inside the final document.
 

--- a/docs/ruler.md
+++ b/docs/ruler.md
@@ -10,11 +10,11 @@ If you need fine-grained control on proportions and where elements are rendered,
 | Prop name            |                    Description                     |                       Type | Default |
 | -------------------- | :------------------------------------------------: | -------------------------: | ------: |
 | ruler                |  Enables vertical and horizontal rulers on page.   |                  _Boolean_ | _false_ |
-| rulerSteps           | Grid separation for horizontal and vertical rulers | _Integer_ _Float_ _String_ |      50 |
+| rulerSteps           | Grid separation for horizontal and vertical rulers | _Integer_, _Float_, _String_ |      50 |
 | verticalRuler        |          Enables vertical ruler on page.           |                  _Boolean_ | _false_ |
-| verticalRulerSteps   |         Grid separation for vertical ruler         | _Integer_ _Float_ _String_ |      50 |
+| verticalRulerSteps   |         Grid separation for vertical ruler         | _Integer_, _Float_, _String_ |      50 |
 | horizontalRuler      |         Enables horizontal ruler on page.          |                  _Boolean_ | _false_ |
-| horizontalRulerSteps |       Grid separation for horizontal rulers        | _Integer_ _Float_ _String_ |      50 |
+| horizontalRulerSteps |       Grid separation for horizontal rulers        | _Integer_, _Float_, _String_ |      50 |
 
 <GoToExample name="ruler" />
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -133,7 +133,7 @@ _Looking for a more neat way of styling your document?_ Now you can take advanta
 
 #### Install
 
-First, you should install styled-components bindings:
+First, you should install styled-components binding:
 
 ```sh
 yarn add @react-pdf/styled-components
@@ -141,7 +141,7 @@ yarn add @react-pdf/styled-components
 
 #### How to use
 
-This bindings follows exactly the same styled-components API, so after installing it you can start creating styled primitives by importing `styled` object from it:
+This binding follows exactly the same styled-components API, so after installing it you can start creating styled primitives by importing `styled` object from it:
 
 ```
 import styled from '@react-pdf/styled-components';

--- a/docs/text.md
+++ b/docs/text.md
@@ -6,11 +6,11 @@ A React component for displaying text. Text supports nesting of other Text or Li
 
 | Prop name           |                                  Description                                  |              Type |     Default |
 |---------------------|:-----------------------------------------------------------------------------:|------------------:|------------:|
-| wrap                |  Enable/disable page wrapping for element [See more](/advanced#page-wrapping) |         _Boolean_ |      _true_ |
-| render              | Render dynamic content based on context [See more](/advanced#dynamic-content) |        _Function_ | _undefined_ |
+| wrap                |  Enables/disables page wrapping for element [See more](/advanced#page-wrapping) |         _Boolean_ |      _true_ |
+| render              | Renders dynamic content based on context [See more](/advanced#dynamic-content) |        _Function_ | _undefined_ |
 | style               |                   Defines view styles. [See more](/styling)                   | _Object_, _Array_ | _undefined_ |
 | debug               |    Enables debug mode on view bounding box. [See more](/advanced#debugging)   |         _Boolean_ |     _false_ |
-| fixed               |   Render component in all wrapped pages. [See more](/advanced#page-wrapping)  |         _Boolean_ |     _false_ |
-| hyphenationCallback |              Specify how much hyphenated breaks should be avoided             |         _Integer_ |       _600_ |
+| fixed               |   Renders component in all wrapped pages. [See more](/advanced#page-wrapping)  |         _Boolean_ |     _false_ |
+| hyphenationCallback |              Specifies how much hyphenated breaks should be avoided             |         _Integer_ |       _600_ |
 
 ---


### PR DESCRIPTION
By profession, I'm a web developer, but a hobbyist teacher (teach English as primary subject) too. Nowadays, learning about react-pdf usage. I encountered some grammatical errors and typos in site docs, so I decided to fix them to contribute to the open-source best pdf-generator package. I proof-read twice after spending 2 hours and now it's corrected. A few other things need to be fixed, which will be done later.