### PR TITLE
Remove unnecessary mnemonic

### DIFF
--- a/docs/orphan-widow-protection.md
+++ b/docs/orphan-widow-protection.md
@@ -2,8 +2,6 @@ import GoToExample from '../src/components/GoToExample'
 
 ### Orphan & widow protection
 
-> _"An orphan has no past; a widow has no future"_
-
 When you layout text, orphans and widows can make the difference between a _good_ document and a _great_ one. That's why react-pdf has a built-in orphan and widow protection that you can use right out of the box.
 
 But react-pdf does not reserve this protection just for text. You can adjust this protection to your convenience by just setting some props to **any react-pdf primitive**:


### PR DESCRIPTION
## Overview

Not only is this mnemonic unnecessary, it literally says "an orphan has no past" and "a widow has no future". It should be clear that these are both incorrect and offensive.

## Screenshot

<img width="930" alt="Screen Shot 2020-08-15 at 9 17 04 PM" src="https://user-images.githubusercontent.com/2440089/90324422-b5d6b380-df3c-11ea-97b7-b0a3a591986f.png">
